### PR TITLE
TCM-355 | Connect `Settings` screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,6 +88,10 @@ android {
             buildConfigField "String", "isMaintenanceMode", '"is_maintenance_mode"'
             buildConfigField "String", "minimumBuildNumber", '"minimum_build_number"'
             buildConfigField "String", "trxUrl", '"http://trx.sprintfwd.com"'
+            buildConfigField "String", "kProductsUrl", '"https://store.trxtraining.com"'
+            buildConfigField "String", "kContactSupportUrl", '"https://www.trxtraining.com/contact-us"'
+            buildConfigField "String", "kTermsConditionsUrl", '"https://www.trxtraining.com/terms-of-use"'
+            buildConfigField "String", "kGettingStartedVideosUrl", '"https://www.trxtraining.com/getting-started"'
             buildConfigField "String", "kBrightcoveAccountId", '"6204326362001"'
             buildConfigField "String", "kBrightcovePolicyKey", '"BCpkADawqM0NIVZ3stgK7lsrNpSnMb54yV2-XP_RMBl9gBL5hOvH_cjmnfU_kxS1QjYqucj3ZQTBRiGZhrd09drVaY-IAEgg9IYebBSliKZI8iSzYpvmdUQgwST2dVv4toFYU1clp89h7_qj"'
             buildConfigField "Boolean", "kIsVerificationEnabled", "false"

--- a/app/src/main/java/com/trx/consumer/core/MainActivity.kt
+++ b/app/src/main/java/com/trx/consumer/core/MainActivity.kt
@@ -2,13 +2,24 @@ package com.trx.consumer.core
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.trx.consumer.R
+import com.trx.consumer.managers.BackendManager
+import com.trx.consumer.managers.CacheManager
 import com.trx.consumer.managers.NavigationManager
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
+
+    @Inject
+    lateinit var backendManager: BackendManager
+
+    @Inject
+    lateinit var cacheManager: CacheManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -19,6 +30,11 @@ class MainActivity : AppCompatActivity() {
 
     private fun start() {
         findViewById<BottomNavigationView>(R.id.tabBar).itemIconTintList = null
-        NavigationManager.shared.launch(this, false)
+        val activity = this
+        lifecycleScope.launch {
+            val isLoggedIn = cacheManager.isLoggedIn()
+            NavigationManager.shared.launch(activity, isLoggedIn)
+            if (!isLoggedIn) backendManager.updateBeforeLogout()
+        }
     }
 }

--- a/app/src/main/java/com/trx/consumer/managers/BackendManager.kt
+++ b/app/src/main/java/com/trx/consumer/managers/BackendManager.kt
@@ -10,6 +10,11 @@ import kotlinx.coroutines.withContext
 
 class BackendManager(private val api: BaseApi, private val cacheManager: CacheManager) {
 
+    suspend fun updateBeforeLogout() {
+        cacheManager.accessToken(null)
+        cacheManager.user(null)
+    }
+
     suspend fun call(request: RequestModel): ResponseModel {
         return withContext(Dispatchers.IO) {
             val endpoint = request.endpoint
@@ -90,6 +95,12 @@ class BackendManager(private val api: BaseApi, private val cacheManager: CacheMa
             cacheManager.user(model.user)
         }
         return response
+    }
+
+    suspend fun logout(): ResponseModel {
+        updateBeforeLogout()
+        val path = EndpointModel.LOGOUT.path
+        return call(RequestModel(endpoint = EndpointModel.LOGOUT, path = path, params = null))
     }
 
     suspend fun workouts(): ResponseModel {

--- a/app/src/main/java/com/trx/consumer/managers/CacheManager.kt
+++ b/app/src/main/java/com/trx/consumer/managers/CacheManager.kt
@@ -23,6 +23,15 @@ class CacheManager(context: Context) {
         val kCurrentUser = preferencesKey<String>("CurrentUser")
     }
 
+    suspend fun isLoggedIn(): Boolean {
+        return withContext(Dispatchers.IO) {
+            dataStore.data.map {
+                val token = Gson().fromJson(it[kBackendAccessToken], String::class.java)
+                !token.isNullOrEmpty()
+            }.firstOrNull() ?: false
+        }
+    }
+
     suspend fun accessToken(): String? {
         return withContext(Dispatchers.IO) {
             dataStore.data.map {

--- a/app/src/main/java/com/trx/consumer/managers/NavigationManager.kt
+++ b/app/src/main/java/com/trx/consumer/managers/NavigationManager.kt
@@ -26,19 +26,20 @@ class NavigationManager {
     private val extraAny = "EXTRA_ANY"
 
     private val listTab =
-        if (BuildConfig.isVersion2Enabled)
+        if (BuildConfig.isVersion2Enabled) {
             listOf(
                 R.id.home_fragment,
                 R.id.virtual_fragment,
                 R.id.live_fragment,
-                R.id.video_fragment
+                R.id.discover_fragment
             )
-        else
+        } else {
             listOf(
                 R.id.home_fragment,
-                R.id.video_fragment,
+                R.id.discover_fragment,
                 R.id.settings_fragment
             )
+        }
 
     private val listIgnoreTab = listOf<Int>()
 

--- a/app/src/main/java/com/trx/consumer/managers/UtilityManager.kt
+++ b/app/src/main/java/com/trx/consumer/managers/UtilityManager.kt
@@ -1,8 +1,10 @@
 package com.trx.consumer.managers
 
+import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.JsonParser
 import com.trx.consumer.BuildConfig
+import com.trx.consumer.extensions.openBrowser
 
 class UtilityManager {
 
@@ -26,6 +28,11 @@ class UtilityManager {
 
     fun versionDisplay(): String {
         return "App Version ${buildVersion()}.${appVersion()}"
+    }
+
+    fun openUrl(context: Context, url: String) {
+        LogManager.log("openUrl: $url")
+        context.openBrowser(url)
     }
 
     companion object {

--- a/app/src/main/java/com/trx/consumer/screens/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/trx/consumer/screens/settings/SettingsFragment.kt
@@ -3,12 +3,19 @@ package com.trx.consumer.screens.settings
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
+import com.trx.consumer.BuildConfig.kContactSupportUrl
+import com.trx.consumer.BuildConfig.kGettingStartedVideosUrl
+import com.trx.consumer.BuildConfig.kProductsUrl
+import com.trx.consumer.BuildConfig.kTermsConditionsUrl
 import com.trx.consumer.R
 import com.trx.consumer.base.BaseFragment
 import com.trx.consumer.base.viewBinding
 import com.trx.consumer.databinding.FragmentSettingsBinding
+import com.trx.consumer.managers.LogManager
 import com.trx.consumer.managers.NavigationManager
 import com.trx.consumer.managers.UtilityManager
+import com.trx.consumer.models.common.AlertModel
+import com.trx.consumer.screens.alert.AlertViewState
 import com.trx.consumer.screens.settings.option.SettingsOptionAdapter
 
 class SettingsFragment : BaseFragment(R.layout.fragment_settings) {
@@ -24,20 +31,74 @@ class SettingsFragment : BaseFragment(R.layout.fragment_settings) {
         viewBinding.rvSettings.adapter = adapter
 
         viewModel.apply {
-            eventTapBack.observe(viewLifecycleOwner, handleTapBack)
             eventLoadView.observe(viewLifecycleOwner, handleLoadView)
+            eventTapSubscriptions.observe(viewLifecycleOwner, handleTapSubscriptions)
+            eventTapContactSupport.observe(viewLifecycleOwner, handleTapContactSupport)
+            eventTapGettingStarted.observe(viewLifecycleOwner, handleTapGetStarted)
+            eventTapTermsAndConditions.observe(viewLifecycleOwner, handleTapTermsAndConditions)
+            eventTapShop.observe(viewLifecycleOwner, handleTapShop)
+            eventTapLogout.observe(viewLifecycleOwner, handleTapLogout)
+            eventLoadView.observe(viewLifecycleOwner, handleLoadView)
+            eventTapBack.observe(viewLifecycleOwner, handleTapBack)
+            eventLogOut.observe(viewLifecycleOwner, handleLogOut)
 
             doLoadView()
         }
     }
 
     private val handleTapBack = Observer<Void> {
+        LogManager.log("handleTapBack")
         NavigationManager.shared.dismiss(this)
     }
 
     private val handleLoadView = Observer<List<Any>> { list ->
+        LogManager.log("handleLoadView")
         viewBinding.lblVersion.text = UtilityManager.shared.versionDisplay()
         adapter.update(list)
+    }
+
+    private val handleTapSubscriptions = Observer<Void> {
+        LogManager.log("handleTapSubscriptions")
+        NavigationManager.shared.present(this, R.id.plans_fragment)
+    }
+
+    private val handleTapContactSupport = Observer<Void> {
+        LogManager.log("handleTapContactSupport")
+        UtilityManager.shared.openUrl(requireContext(), kContactSupportUrl)
+    }
+
+    private val handleTapGetStarted = Observer<Void> {
+        LogManager.log("handleTapGetStarted")
+        UtilityManager.shared.openUrl(requireContext(), kGettingStartedVideosUrl)
+    }
+
+    private val handleTapTermsAndConditions = Observer<Void> {
+        LogManager.log("handleTapTermsAndConditions")
+        UtilityManager.shared.openUrl(requireContext(), kTermsConditionsUrl)
+    }
+
+    private val handleTapShop = Observer<Void> {
+        LogManager.log("handleTapShop")
+        UtilityManager.shared.openUrl(requireContext(), kProductsUrl)
+    }
+
+    private val handleTapLogout = Observer<Void> {
+        LogManager.log("handleTapLogout")
+        val context = requireContext()
+        val model = AlertModel.create(
+            title = context.getString(R.string.alert_confirm_message),
+            message = context.getString(R.string.alert_logout_message)
+        )
+        model.setPrimaryButton(R.string.alert_nevermind_label, AlertViewState.NEUTRAL)
+        model.setSecondaryButton(R.string.alert_logout_confirm_label, AlertViewState.NEGATIVE) {
+            viewModel.updateBeforeLogout()
+        }
+        NavigationManager.shared.present(this, R.id.alert_fragment, model)
+    }
+
+    private val handleLogOut = Observer<Void> {
+        LogManager.log("handleLogOut")
+        NavigationManager.shared.notLoggedInLaunchSequence(this)
     }
 
     override fun onBackPressed() {

--- a/app/src/main/java/com/trx/consumer/screens/settings/SettingsModel.kt
+++ b/app/src/main/java/com/trx/consumer/screens/settings/SettingsModel.kt
@@ -16,6 +16,7 @@ class SettingsModel {
     val subtitle: String
         get() =
             when (type) {
+                // TODO: Display text based on user's subscription
                 SettingsType.SUBSCRIPTIONS -> "ACTIVE | Renews Oct. 29, 2020"
                 else -> ""
             }
@@ -41,18 +42,16 @@ class SettingsModel {
             }
 
         fun list(user: UserModel?): List<Any> {
-            return mutableListOf<Any>().apply {
-                add(create(user, SettingsType.SUBSCRIPTIONS))
-                add(0)
-                add(create(null, SettingsType.SHOP))
-                add(create(null, SettingsType.GETTING_STARTED))
-                add(create(null, SettingsType.CONTACT_SUPPORT))
-                add(create(null, SettingsType.TERMS_AND_CONDITIONS))
-                add(0)
-                add(create(null, SettingsType.RESTORE_PURCHASES))
-                add(0)
-                add(create(null, SettingsType.LOGOUT))
-            }
+            return listOf(
+                create(user, SettingsType.SUBSCRIPTIONS),
+                0,
+                create(null, SettingsType.SHOP),
+                create(null, SettingsType.GETTING_STARTED),
+                create(null, SettingsType.CONTACT_SUPPORT),
+                create(null, SettingsType.TERMS_AND_CONDITIONS),
+                0,
+                create(null, SettingsType.LOGOUT)
+            )
         }
     }
 }
@@ -63,7 +62,7 @@ enum class SettingsType {
     GETTING_STARTED,
     CONTACT_SUPPORT,
     TERMS_AND_CONDITIONS,
-    RESTORE_PURCHASES,
+    RESTORE,
     LOGOUT;
 
     @get:StringRes
@@ -74,7 +73,7 @@ enum class SettingsType {
             GETTING_STARTED -> R.string.settings_getting_started
             TERMS_AND_CONDITIONS -> R.string.settings_terms_and_conditions
             CONTACT_SUPPORT -> R.string.settings_contact_support
-            RESTORE_PURCHASES -> R.string.settings_restore_purchases
+            RESTORE -> R.string.settings_restore_purchases
             LOGOUT -> R.string.settings_logout
         }
 }

--- a/app/src/main/java/com/trx/consumer/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/trx/consumer/screens/settings/SettingsViewModel.kt
@@ -1,23 +1,61 @@
 package com.trx.consumer.screens.settings
 
+import androidx.hilt.lifecycle.ViewModelInject
+import androidx.lifecycle.viewModelScope
 import com.trx.consumer.base.BaseViewModel
 import com.trx.consumer.common.CommonLiveEvent
-import com.trx.consumer.models.common.UserModel
+import com.trx.consumer.managers.BackendManager
+import com.trx.consumer.managers.CacheManager
 import com.trx.consumer.screens.settings.option.SettingsOptionListener
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
-class SettingsViewModel : BaseViewModel(), SettingsOptionListener {
+class SettingsViewModel @ViewModelInject constructor(
+    private val backendManager: BackendManager,
+    private val cacheManager: CacheManager
+) : BaseViewModel(), SettingsOptionListener {
 
+    val eventTapSubscriptions = CommonLiveEvent<Void>()
+    val eventTapTermsAndConditions = CommonLiveEvent<Void>()
+    val eventTapContactSupport = CommonLiveEvent<Void>()
+    val eventTapGettingStarted = CommonLiveEvent<Void>()
+    val eventTapShop = CommonLiveEvent<Void>()
+    val eventTapLogout = CommonLiveEvent<Void>()
     val eventTapBack = CommonLiveEvent<Void>()
     val eventLoadView = CommonLiveEvent<List<Any>>()
+
+    val eventLogOut = CommonLiveEvent<Void>()
 
     fun doTapBack() {
         eventTapBack.call()
     }
 
     fun doLoadView() {
-        eventLoadView.postValue(SettingsModel.list(UserModel.test()))
+        viewModelScope.launch {
+            cacheManager.user()?.let { user ->
+                eventLoadView.postValue(SettingsModel.list(user))
+            }
+        }
+    }
+
+    fun updateBeforeLogout() {
+        CoroutineScope(Dispatchers.IO).launch {
+            backendManager.logout()
+        }
+        eventLogOut.call()
     }
 
     override fun doTapSettings(model: SettingsModel) {
+        when (model.type) {
+            SettingsType.SUBSCRIPTIONS -> eventTapSubscriptions.call()
+            SettingsType.SHOP -> eventTapShop.call()
+            SettingsType.GETTING_STARTED -> eventTapGettingStarted.call()
+            SettingsType.CONTACT_SUPPORT -> eventTapContactSupport.call()
+            SettingsType.TERMS_AND_CONDITIONS -> eventTapTermsAndConditions.call()
+            SettingsType.RESTORE -> {
+            }
+            SettingsType.LOGOUT -> eventTapLogout.call()
+        }
     }
 }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -9,7 +9,7 @@
     <com.trx.consumer.common.CommonView
         android:id="@+id/viewHeader"
         android:layout_width="match_parent"
-        android:layout_height="150dp"
+        android:layout_height="60dp"
         app:layout_constraintTop_toTopOf="parent">
 
         <com.trx.consumer.common.CommonLabel

--- a/app/src/main/res/menu/menu_bottom_nav.xml
+++ b/app/src/main/res/menu/menu_bottom_nav.xml
@@ -7,7 +7,7 @@
         android:title="@string/tab_home" />
 
     <item
-        android:id="@+id/video_fragment"
+        android:id="@+id/discover_fragment"
         android:icon="@drawable/ic_tab_video_toggle"
         android:title="@string/tab_on_demand" />
 

--- a/app/src/main/res/menu/menu_bottom_nav_v2.xml
+++ b/app/src/main/res/menu/menu_bottom_nav_v2.xml
@@ -17,7 +17,7 @@
         android:title="@string/tab_live" />
 
     <item
-        android:id="@+id/video_fragment"
+        android:id="@+id/discover_fragment"
         android:icon="@drawable/ic_tab_video_toggle"
         android:title="@string/tab_on_demand" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,10 @@
     <string name="alert_button_title_dismiss">Dismiss</string>
     <string name="alert_primary_back">Take me back</string>
     <string name="alert_secondary_report">Report an issue</string>
+    <string name="alert_confirm_message">Are you sure?</string>
+    <string name="alert_nevermind_label">Nevermind</string>
+    <string name="alert_logout_message">You will be logged out</string>
+    <string name="alert_logout_confirm_label">Yes, log me out</string>
 
     <string name="booking_view_state_book_label">BOOK</string>
     <string name="booking_view_state_booked_label">BOOKED</string>


### PR DESCRIPTION
## Description
Connect the `Settings` options to their appropriate screens

### Summary

- [x] Make `Settings` screen design improvements
- [x] Connect each Settings option to its appropriate screen
- [x] Persist login and logout
- [x] Fix on demand tab navigation bug  

### Issue

[TCM-355](https://hyfnla.atlassian.net/browse/TCM-355)

### Video/Screenshot

[On demand tab](https://drive.google.com/file/d/1V3X9KX387SqkxJ_NfrAkJgELdxATsJ8w/view?usp=sharing)
[Persist login](https://drive.google.com/file/d/1E9CDvNHSNe-t_kuhn3UOYVnIJoMxt2EK/view?usp=sharing)
[Settings log out + persist](https://drive.google.com/file/d/14iTObIW356AMXi63wnliLMjaNsnGGbwM/view?usp=sharing)
[Settings supscriptions](https://drive.google.com/file/d/1ELEmkvbVMJMX1Fa1qfqC8UugLgGB9L2p/view?usp=sharing)
[Settings url options](https://drive.google.com/file/d/1pmywyRs5ZtXUNXRAI_9Y6CTzH687xcd5/view?usp=sharing)