### PR TITLE
TCM-421 |  Polish `Home` screen

### DIFF
--- a/app/src/main/java/com/trx/consumer/models/responses/UserResponseModel.kt
+++ b/app/src/main/java/com/trx/consumer/models/responses/UserResponseModel.kt
@@ -9,7 +9,7 @@ class UserResponseModel(val user: UserModel, val jwt: String = "") {
 
         fun parse(json: String): UserResponseModel {
             val jsonObject = JSONObject(json)
-            val userObject = jsonObject.optJSONObject("user")
+            val userObject = jsonObject.optJSONObject("data")
             val user = userObject?.let { UserModel.parse(it) } ?: UserModel()
             val jwt = jsonObject.optString("jwt")
             return UserResponseModel(user, jwt)

--- a/app/src/main/java/com/trx/consumer/screens/home/HomeFragment.kt
+++ b/app/src/main/java/com/trx/consumer/screens/home/HomeFragment.kt
@@ -54,6 +54,7 @@ class HomeFragment : BaseFragment(R.layout.fragment_home) {
 
             eventTapBanner.observe(viewLifecycleOwner, handleTapBanner)
             eventTapUser.observe(viewLifecycleOwner, handleTapUser)
+            eventShowVideo.observe(viewLifecycleOwner, handleShowVideo)
 
             eventShowPromo.observe(viewLifecycleOwner, handleShowPromo)
             eventShowHud.observe(viewLifecycleOwner, handleShowHud)
@@ -102,6 +103,11 @@ class HomeFragment : BaseFragment(R.layout.fragment_home) {
     private val handleTapUser = Observer<Void> {
         LogManager.log("handleTapUser")
         NavigationManager.shared.present(this, R.id.profile_fragment)
+    }
+
+    private val handleShowVideo = Observer<VideoModel> { model ->
+        LogManager.log("handleShowVideo")
+        NavigationManager.shared.present(this, R.id.workout_fragment, model)
     }
 
     private val handleShowPromo = Observer<PromoModel> { promo ->

--- a/app/src/main/java/com/trx/consumer/screens/home/HomeFragment.kt
+++ b/app/src/main/java/com/trx/consumer/screens/home/HomeFragment.kt
@@ -142,17 +142,19 @@ class HomeFragment : BaseFragment(R.layout.fragment_home) {
     }
 
     private fun loadPromos(promos: List<PromoModel>) {
+        val hide = promos.isEmpty()
         promoAdapter.update(promos)
         viewBinding.apply {
             viewPromos.lblTitle.text = getString(R.string.promos_top_title_label)
             viewPromos.viewMain.isHidden = promos.isEmpty()
+            imgLineForYou.isHidden = hide
+            viewPromos.viewMain.isHidden = hide
         }
     }
 
     private fun loadUser(model: UserModel) {
         viewBinding.apply {
             with(requireContext()) {
-                // Temporary, logic will likely change
                 lblUserName.text = getString(R.string.home_user_name_label, model.firstName)
             }
         }

--- a/app/src/main/java/com/trx/consumer/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/trx/consumer/screens/home/HomeViewModel.kt
@@ -51,9 +51,16 @@ class HomeViewModel @ViewModelInject constructor(
 
     fun doLoadView() {
         eventLoadView.call()
+        doLoadUser()
+    }
+
+    fun doLoadUser() {
         viewModelScope.launch {
-            cacheManager.user()?.let { user ->
-                eventLoadUser.postValue(user)
+            val response = backendManager.user()
+            if(response.isSuccess) {
+                cacheManager.user()?.let { user ->
+                    eventLoadUser.postValue(user)
+                }
             }
         }
     }

--- a/app/src/main/java/com/trx/consumer/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/trx/consumer/screens/home/HomeViewModel.kt
@@ -57,7 +57,7 @@ class HomeViewModel @ViewModelInject constructor(
     fun doLoadUser() {
         viewModelScope.launch {
             val response = backendManager.user()
-            if(response.isSuccess) {
+            if (response.isSuccess) {
                 cacheManager.user()?.let { user ->
                     eventLoadUser.postValue(user)
                 }

--- a/app/src/main/java/com/trx/consumer/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/trx/consumer/screens/home/HomeViewModel.kt
@@ -50,7 +50,11 @@ class HomeViewModel @ViewModelInject constructor(
 
     fun doLoadView() {
         eventLoadView.call()
-        eventLoadUser.postValue(UserModel.test())
+        viewModelScope.launch {
+            cacheManager.user()?.let { user ->
+                eventLoadUser.postValue(user)
+            }
+        }
     }
 
     fun doTapTest() {

--- a/app/src/main/java/com/trx/consumer/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/trx/consumer/screens/home/HomeViewModel.kt
@@ -40,6 +40,7 @@ class HomeViewModel @ViewModelInject constructor(
     val eventTapTest = CommonLiveEvent<Void>()
     val eventTapBanner = CommonLiveEvent<String>()
     val eventTapUser = CommonLiveEvent<Void>()
+    val eventShowVideo = CommonLiveEvent<VideoModel>()
 
     val eventShowPromo = CommonLiveEvent<PromoModel>()
     val eventShowHud = CommonLiveEvent<Boolean>()
@@ -106,6 +107,7 @@ class HomeViewModel @ViewModelInject constructor(
     }
 
     override fun doTapVideo(model: VideoModel) {
+        eventShowVideo.postValue(model)
         analyticsManager.trackAmplitude(AnalyticsEventModel.VIEW_VIDEO_DETAIL_ID, model.id)
     }
 

--- a/app/src/main/java/com/trx/consumer/screens/videos/VideosViewModel.kt
+++ b/app/src/main/java/com/trx/consumer/screens/videos/VideosViewModel.kt
@@ -5,8 +5,6 @@ import com.trx.consumer.common.CommonLiveEvent
 import com.trx.consumer.models.common.TrainerModel
 import com.trx.consumer.models.common.VideoModel
 import com.trx.consumer.models.common.VideosModel
-import com.trx.consumer.models.common.WorkoutModel
-import com.trx.consumer.models.states.BookingState
 import com.trx.consumer.screens.discover.list.DiscoverListener
 
 class VideosViewModel : BaseViewModel(), DiscoverListener {

--- a/app/src/main/res/layout/fragment_workout.xml
+++ b/app/src/main/res/layout/fragment_workout.xml
@@ -29,6 +29,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
                     android:scaleType="centerCrop"
+                    android:tint="@color/blackAlpha20"
                     app:layout_constraintBottom_toBottomOf="@+id/viewHeader"
                     app:layout_constraintTop_toTopOf="@+id/viewHeader" />
 

--- a/app/src/main/res/layout/row_video_workout_table.xml
+++ b/app/src/main/res/layout/row_video_workout_table.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="160dp"
-    android:layout_marginBottom="15dp">
+    android:layout_marginStart="15dp">
 
     <include layout="@layout/row_video_workout" />
 


### PR DESCRIPTION
## Description

### Summary

- [x] Start margin and spacing added between on demand video workout cells.
- [x] Title and dividers are only visible when list is not empty.
- [x] User first named displayed instead Test name.
- [x] On-Demand video made clickable.
- [x] Tint added to workout screen header image background.

### Issue

[TCM-421](https://hyfnla.atlassian.net/browse/TCM-421)

### Video/Screenshot

| With on-demand Video | Without promo | 
|---|---|
|![Screenshot_1622227873](https://user-images.githubusercontent.com/24737954/120035861-1dce2600-bfb4-11eb-9196-406dd827baaa.png)|![Screenshot_1622228387](https://user-images.githubusercontent.com/24737954/120035895-2cb4d880-bfb4-11eb-95c7-d0e5e241443b.png)|

### Video Demo

https://user-images.githubusercontent.com/24737954/120038164-aac6ae80-bfb7-11eb-8c43-e44184324156.mov

