### PR TITLE
TCM-507 | Disable clicking for skeleton views in `Discover`

### DIFF
--- a/app/src/main/java/com/trx/consumer/screens/videoworkout/VideoWorkoutViewHolder.kt
+++ b/app/src/main/java/com/trx/consumer/screens/videoworkout/VideoWorkoutViewHolder.kt
@@ -26,7 +26,7 @@ class VideoWorkoutViewHolder(view: View) : CommonViewHolder(view) {
             lblTitle.applySkeleton(isSkeleton, name)
             lblSubtitle.applySkeleton(isSkeleton, "with ${trainer.displayName}")
             imgBg.applySkeleton(isSkeleton, color = R.color.black, urlString = poster)
-            btnSelect.action { listener.doTapVideo(item) }
+            if (!isSkeleton) btnSelect.action { listener.doTapVideo(item) }
         }
     }
 
@@ -37,7 +37,7 @@ class VideoWorkoutViewHolder(view: View) : CommonViewHolder(view) {
             lblTitle.applySkeleton(isSkeleton, title)
             lblSubtitle.applySkeleton(isSkeleton, "with ${trainer.displayName}")
             imgBg.applySkeleton(isSkeleton, color = R.color.black, urlString = poster)
-            btnSelect.action { listener.doTapVideos(item) }
+            if (!isSkeleton) btnSelect.action { listener.doTapVideos(item) }
         }
     }
 


### PR DESCRIPTION
## Description
Ensure skeleton views are not clickable

### Summary

- [x] Check for skeleton item before setting action

### Issue

[TCM-507](https://hyfnla.atlassian.net/browse/TCM-507)

### Video/Screenshot

https://user-images.githubusercontent.com/39810816/121250919-e55c0100-c86b-11eb-8ff9-35d9e1828c39.mov

