### PR TITLE
TCM-626 | Add 'android' Prefix to Remote Config Keys

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -87,8 +87,8 @@ android {
             buildConfigField "Integer", "kZipcodeMinLength", "5"
             buildConfigField "Integer", "kDefaultTextLimit", "40"
             buildConfigField "Integer", "kPasswordMinLength", "6"
-            buildConfigField "String", "isMaintenanceMode", '"is_maintenance_mode"'
-            buildConfigField "String", "minimumBuildNumber", '"minimum_build_number"'
+            buildConfigField "String", "isMaintenanceMode", '"android_is_maintenance_mode"'
+            buildConfigField "String", "minimumBuildNumber", '"android_minimum_build_number"'
             buildConfigField "String", "trxUrl", '"http://trx.sprintfwd.com"'
             buildConfigField "String", "kProductsUrl", '"https://store.trxtraining.com"'
             buildConfigField "String", "kContactSupportUrl", '"https://www.trxtraining.com/contact-us"'


### PR DESCRIPTION
## Description

### Summary

- [x] Added the prefix to isMaintenanceMode and minimumBuildNumber in build config

### Issue

[TCM-626](https://hyfnla.atlassian.net/browse/TCM-626)

### Video/Screenshot

#### IsMaintenanceMode
<img width="1330" alt="Screen Shot 2021-06-23 at 4 45 56 PM" src="https://user-images.githubusercontent.com/24737954/123182173-b89b1280-d443-11eb-8afc-e554242c5bcd.png">

#### MinimumBuildNumber
<img width="1331" alt="Screen Shot 2021-06-23 at 4 45 09 PM" src="https://user-images.githubusercontent.com/24737954/123182134-a620d900-d443-11eb-9217-c11f76d271b6.png">
