### PR TITLE
TCM-566 | Implement cancel memberships flows

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,7 +89,7 @@ android {
             buildConfigField "Integer", "kPasswordMinLength", "6"
             buildConfigField "String", "isMaintenanceMode", '"is_maintenance_mode"'
             buildConfigField "String", "minimumBuildNumber", '"minimum_build_number"'
-            buildConfigField "String", "trxUrl", '"http://trx.sprintfwd.com"'
+            buildConfigField "String", "trxUrl", '"https://digital.trxtraining.com"'
             buildConfigField "String", "kProductsUrl", '"https://store.trxtraining.com"'
             buildConfigField "String", "kContactSupportUrl", '"https://www.trxtraining.com/contact-us"'
             buildConfigField "String", "kTermsConditionsUrl", '"https://www.trxtraining.com/terms-of-use"'

--- a/app/src/main/java/com/trx/consumer/managers/NativePurchaseManager.kt
+++ b/app/src/main/java/com/trx/consumer/managers/NativePurchaseManager.kt
@@ -38,7 +38,7 @@ class NativePurchaseManager(private val context: Context) {
         }
     }
 
-    suspend fun getPurchases(): List<Purchase> {
+    suspend fun purchases(): List<Purchase> {
         return withContext(Dispatchers.IO) {
             val isConnected = if (billingClient.isReady) true else connect()
             if (isConnected) {

--- a/app/src/main/java/com/trx/consumer/models/common/SettingsModel.kt
+++ b/app/src/main/java/com/trx/consumer/models/common/SettingsModel.kt
@@ -17,7 +17,7 @@ class SettingsModel {
         get() =
             when (type) {
                 SettingsType.MEMBERSHIPS -> {
-                    val size = user?.memberships?.size ?: 0
+                    val size = user?.activeMemberships?.size ?: 0
                     "$size active membership${if (size == 1) "" else "s"}"
                 }
                 SettingsType.EMAIL -> user?.email ?: "N/A"

--- a/app/src/main/java/com/trx/consumer/models/common/UserMembershipModel.kt
+++ b/app/src/main/java/com/trx/consumer/models/common/UserMembershipModel.kt
@@ -5,7 +5,8 @@ import org.json.JSONObject
 class UserMembershipModel(
     val cancelAtPeriodEnd: Boolean = false,
     val currentPeriodEnd: Long = 0,
-    val currentPeriodStart: Long = 0
+    val currentPeriodStart: Long = 0,
+    val isActive: Boolean = false,
 ) {
 
     companion object {
@@ -14,7 +15,8 @@ class UserMembershipModel(
             return UserMembershipModel(
                 cancelAtPeriodEnd = jsonObject.optBoolean("cancel_at_period_end"),
                 currentPeriodEnd = jsonObject.optLong("current_period_end"),
-                currentPeriodStart = jsonObject.optLong("current_period_start")
+                currentPeriodStart = jsonObject.optLong("current_period_start"),
+                isActive = jsonObject.optString("status") == "active"
             )
         }
     }

--- a/app/src/main/java/com/trx/consumer/models/common/UserMembershipModel.kt
+++ b/app/src/main/java/com/trx/consumer/models/common/UserMembershipModel.kt
@@ -5,8 +5,12 @@ import org.json.JSONObject
 class UserMembershipModel(
     val cancelAtPeriodEnd: Boolean = false,
     val currentPeriodEnd: Long = 0,
-    val currentPeriodStart: Long = 0
+    val currentPeriodStart: Long = 0,
+    val status: String = ""
 ) {
+
+    val isActive: Boolean
+        get() = status == "active"
 
     companion object {
 
@@ -14,7 +18,8 @@ class UserMembershipModel(
             return UserMembershipModel(
                 cancelAtPeriodEnd = jsonObject.optBoolean("cancel_at_period_end"),
                 currentPeriodEnd = jsonObject.optLong("current_period_end"),
-                currentPeriodStart = jsonObject.optLong("current_period_start")
+                currentPeriodStart = jsonObject.optLong("current_period_start"),
+                status = jsonObject.optString("status")
             )
         }
     }

--- a/app/src/main/java/com/trx/consumer/models/common/UserMembershipModel.kt
+++ b/app/src/main/java/com/trx/consumer/models/common/UserMembershipModel.kt
@@ -5,8 +5,7 @@ import org.json.JSONObject
 class UserMembershipModel(
     val cancelAtPeriodEnd: Boolean = false,
     val currentPeriodEnd: Long = 0,
-    val currentPeriodStart: Long = 0,
-    val isActive: Boolean = false,
+    val currentPeriodStart: Long = 0
 ) {
 
     companion object {
@@ -15,8 +14,7 @@ class UserMembershipModel(
             return UserMembershipModel(
                 cancelAtPeriodEnd = jsonObject.optBoolean("cancel_at_period_end"),
                 currentPeriodEnd = jsonObject.optLong("current_period_end"),
-                currentPeriodStart = jsonObject.optLong("current_period_start"),
-                isActive = jsonObject.optString("status") == "active"
+                currentPeriodStart = jsonObject.optLong("current_period_start")
             )
         }
     }

--- a/app/src/main/java/com/trx/consumer/models/common/UserModel.kt
+++ b/app/src/main/java/com/trx/consumer/models/common/UserModel.kt
@@ -20,6 +20,9 @@ class UserModel(
     val fullName: String
         get() = "$firstName $lastName"
 
+    val activeMemberships: Map<String, UserMembershipModel>
+        get() = memberships.filter { it.value.isActive }
+
     companion object {
 
         fun parse(jsonObject: JSONObject): UserModel {

--- a/app/src/main/java/com/trx/consumer/models/responses/MembershipsResponseModel.kt
+++ b/app/src/main/java/com/trx/consumer/models/responses/MembershipsResponseModel.kt
@@ -40,7 +40,7 @@ class MembershipsResponseModel(
         }
     }
 
-    fun memberships(userMemberships: HashMap<String, UserMembershipModel>): List<MembershipModel> {
+    fun memberships(userMemberships: Map<String, UserMembershipModel>): List<MembershipModel> {
         val memberships = mutableListOf<MembershipModel>()
 
         match(customMemberships, userMemberships)
@@ -63,7 +63,7 @@ class MembershipsResponseModel(
 
     private fun match(
         memberships: List<MembershipModel>,
-        userMemberships: HashMap<String, UserMembershipModel>
+        userMemberships: Map<String, UserMembershipModel>
     ) {
         memberships.forEach { membership ->
             userMemberships[membership.key]?.let { matchingPlan ->

--- a/app/src/main/java/com/trx/consumer/screens/liveplayer/LivePlayerActivity.kt
+++ b/app/src/main/java/com/trx/consumer/screens/liveplayer/LivePlayerActivity.kt
@@ -2,9 +2,7 @@ package com.trx.consumer.screens.liveplayer
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.lifecycleScope
 import com.trx.consumer.R
-import kotlinx.coroutines.launch
 
 class LivePlayerActivity : AppCompatActivity() {
 

--- a/app/src/main/java/com/trx/consumer/screens/memberships/MembershipsFragment.kt
+++ b/app/src/main/java/com/trx/consumer/screens/memberships/MembershipsFragment.kt
@@ -1,9 +1,9 @@
 package com.trx.consumer.screens.memberships
 
-import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
+import com.trx.consumer.BuildConfig
 import com.trx.consumer.R
 import com.trx.consumer.base.BaseFragment
 import com.trx.consumer.base.viewBinding
@@ -12,6 +12,7 @@ import com.trx.consumer.extensions.action
 import com.trx.consumer.extensions.isHidden
 import com.trx.consumer.managers.LogManager
 import com.trx.consumer.managers.NavigationManager
+import com.trx.consumer.managers.UtilityManager
 import com.trx.consumer.models.common.AlertModel
 import com.trx.consumer.models.common.MembershipModel
 import com.trx.consumer.screens.alert.AlertViewState
@@ -39,7 +40,9 @@ class MembershipsFragment : BaseFragment(R.layout.fragment_memberships) {
             eventLoadView.observe(viewLifecycleOwner, handleLoadView)
             eventLoadError.observe(viewLifecycleOwner, handleLoadError)
             eventTapChooseMembership.observe(viewLifecycleOwner, handleTapChooseMembership)
-            eventTapCancelMembership.observe(viewLifecycleOwner, handleTapCancelMembership)
+            eventShowCancelActive.observe(viewLifecycleOwner, handleShowCancelActive)
+            eventShowCancelMobile.observe(viewLifecycleOwner, handleShowCancelMobile)
+            eventShowCancelWeb.observe(viewLifecycleOwner, handleShowCancelWeb)
             eventShowHud.observe(viewLifecycleOwner, handleShowHud)
 
             doLoadView()
@@ -74,32 +77,57 @@ class MembershipsFragment : BaseFragment(R.layout.fragment_memberships) {
                 R.string.memberships_choose_membership_alert_primary_label,
                 state = AlertViewState.POSITIVE
             ) { viewModel.doCallSubscribe(requireActivity(), membership) }
-            setSecondaryButton(R.string.memberships_choose_membership_alert_secondary_label)
+            setSecondaryButton(R.string.memberships_alert_secondary_label)
         }
         NavigationManager.shared.present(this, R.id.alert_fragment, model)
     }
 
-    private val handleTapCancelMembership = Observer<MembershipModel> {
-        LogManager.log("handleTapCancelMembership")
+    private val handleShowCancelActive = Observer<Void> {
+        LogManager.log("handleShowCancelActive")
+        val model = AlertModel.create(
+            title = "",
+            message = requireContext()
+                .getString(R.string.memberships_show_cancel_active_alert_message)
+        ).apply {
+            setPrimaryButton(
+                R.string.memberships_show_cancel_active_primary_label,
+                state = AlertViewState.POSITIVE
+            )
+            setSecondaryButton(R.string.memberships_alert_secondary_label)
+        }
+        NavigationManager.shared.present(this, R.id.alert_fragment, model)
+    }
+
+    private val handleShowCancelMobile = Observer<Void> {
+        LogManager.log("handleShowCancelMobile")
         val context = requireContext()
         val model = AlertModel.create(
             title = "",
-            message = context.getString(R.string.memberships_cancel_membership_alert_message)
+            message = context.getString(R.string.memberships_show_cancel_mobile_alert_message)
         ).apply {
             setPrimaryButton(
-                R.string.memberships_cancel_membership_alert_primary_label,
+                R.string.memberships_show_cancel_mobile_alert_primary_label,
                 state = AlertViewState.POSITIVE
-            )
-            setSecondaryButton(R.string.memberships_cancel_membership_alert_secondary_label) {
-                val model = ErrorAlertModel.error(
-                    context.getString(R.string.memberships_cancel_wip_label)
-                )
-                NavigationManager.shared.present(
-                    this@MembershipsFragment,
-                    R.id.error_fragment,
-                    model
-                )
+            ) { UtilityManager.shared.openUrl(context, BuildConfig.kGooglePlaySubscriptionsUrl) }
+            setSecondaryButton(R.string.memberships_alert_secondary_label)
+        }
+        NavigationManager.shared.present(this, R.id.alert_fragment, model)
+    }
+
+    private val handleShowCancelWeb = Observer<Void> {
+        LogManager.log("handleShowCancelWeb")
+        val context = requireContext()
+        val model = AlertModel.create(
+            title = "",
+            message = context.getString(R.string.memberships_show_cancel_web_alert_message)
+        ).apply {
+            setPrimaryButton(
+                R.string.memberships_show_cancel_web_primary_label,
+                state = AlertViewState.POSITIVE
+            ) {
+                UtilityManager.shared.openUrl(context, BuildConfig.trxUrl)
             }
+            setSecondaryButton(R.string.memberships_alert_secondary_label)
         }
         NavigationManager.shared.present(this, R.id.alert_fragment, model)
     }

--- a/app/src/main/java/com/trx/consumer/screens/memberships/MembershipsViewModel.kt
+++ b/app/src/main/java/com/trx/consumer/screens/memberships/MembershipsViewModel.kt
@@ -58,7 +58,7 @@ class MembershipsViewModel @ViewModelInject constructor(
                 )
                 val user = UserResponseModel.parse(userResponse.responseString).user
                 cacheManager.user(user)
-                memberships = membershipsResponseModel.memberships(user.memberships)
+                memberships = membershipsResponseModel.memberships(user.activeMemberships)
                 eventLoadView.postValue(memberships)
             } catch (e: Exception) {
                 LogManager.log(e)

--- a/app/src/main/java/com/trx/consumer/screens/memberships/list/MembershipViewState.kt
+++ b/app/src/main/java/com/trx/consumer/screens/memberships/list/MembershipViewState.kt
@@ -37,5 +37,4 @@ enum class MembershipViewState {
             CANCELLED -> R.string.memberships_cancelled_membership_label
             else -> R.string.memberships_cancel_membership_label
         }
-
 }

--- a/app/src/main/java/com/trx/consumer/screens/memberships/list/MembershipsViewHolder.kt
+++ b/app/src/main/java/com/trx/consumer/screens/memberships/list/MembershipsViewHolder.kt
@@ -38,7 +38,7 @@ class MembershipsViewHolder(view: View) : CommonViewHolder(view) {
         viewBottom.isVisible = state == MembershipViewState.ACTIVE
         btnCancel.apply {
             text = context.getString(state.cancelButtonText)
-            action { listener.doTapCancel(item) }
+            action { if (!item.isCancelled) listener.doTapCancel(item) }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,13 +120,15 @@
     <string name="memberships_restore_purchases_label">Restore Purchases</string>
     <string name="memberships_cancel_membership_label">Cancel Membership</string>
     <string name="memberships_cancelled_membership_label">Cancelled Membership</string>
-    <string name="memberships_cancel_membership_alert_message">Are you sure you want to cancel your membership? (canceling may take up to 24 hours)</string>
     <string name="memberships_choose_membership_alert_message">Are you sure you want to buy this membership?</string>
-    <string name="memberships_cancel_membership_alert_primary_label">NO, KEEP MY MEMBERSHIP</string>
-    <string name="memberships_cancel_membership_alert_secondary_label">YES, CANCEL MY MEMBERSHIP</string>
-    <string name="memberships_cancel_wip_label">Under construction</string>
     <string name="memberships_choose_membership_alert_primary_label">SUBMIT PAYMENT</string>
-    <string name="memberships_choose_membership_alert_secondary_label">DISMISS</string>
+    <string name="memberships_show_cancel_mobile_alert_message">To cancel this membership you must cancel through the Play Store app</string>
+    <string name="memberships_show_cancel_mobile_alert_primary_label">GO TO PLAY STORE</string>
+    <string name="memberships_show_cancel_active_alert_message">To buy this membership you must cancel your current membership</string>
+    <string name="memberships_show_cancel_active_primary_label">GO TO MEMBERSHIPS</string>
+    <string name="memberships_show_cancel_web_alert_message">This membership was not bought with the signed in Google account</string>
+    <string name="memberships_show_cancel_web_primary_label">GO TO WEBSITE</string>
+    <string name="memberships_alert_secondary_label">DISMISS</string>
     <string name="memberships_last_bill_date_label">Last Bill Date:</string>
     <string name="memberships_next_bill_date_label">Next Bill Date:</string>
 


### PR DESCRIPTION
## Description
Handle various cancellation flows

### Summary

- [x] Only allow user to purchase a membership if none are active
- [x] Take user to website when cancelling if active membership is not in native purchases 
- [x] Take user to play store subscriptions when cancelling if active membership is in native purchases
- [x] Always check for `active` user memberships in user response 

### Issue

[TCM-566](https://hyfnla.atlassian.net/browse/TCM-566)

### Video/Screenshot

https://user-images.githubusercontent.com/39810816/123190302-eb093780-d464-11eb-8483-5aeb6184cc0a.mov

https://user-images.githubusercontent.com/39810816/123190305-eba1ce00-d464-11eb-9412-f6dcfb5386c5.mov

