### PR TITLE
TCM-579 | Introduce `Restore` screen

### DIFF
--- a/app/src/main/java/com/trx/consumer/extensions/PackageExtensions.kt
+++ b/app/src/main/java/com/trx/consumer/extensions/PackageExtensions.kt
@@ -1,0 +1,13 @@
+package com.trx.consumer.extensions
+
+import com.revenuecat.purchases.Package
+
+fun Package.params(entitlement: String): HashMap<String, Any> {
+    return hashMapOf(
+        "subscriptionType" to entitlement,
+        "currency" to product.priceCurrencyCode,
+        "subscriptionId" to product.sku,
+        "paymentProcessor" to "REVCAT",
+        "priceInCents" to (product.priceAmountMicros / 10000)
+    )
+}

--- a/app/src/main/java/com/trx/consumer/managers/CacheManager.kt
+++ b/app/src/main/java/com/trx/consumer/managers/CacheManager.kt
@@ -5,7 +5,6 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.preferencesKey
 import androidx.datastore.preferences.createDataStore
 import com.google.gson.Gson
-import com.trx.consumer.BuildConfig.isVersion2Enabled
 import com.trx.consumer.models.common.UserModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
@@ -104,7 +103,7 @@ class CacheManager(context: Context) {
     suspend fun didShowRestore(): Boolean {
         return withContext(Dispatchers.IO) {
             dataStore.data.map {
-                if (isVersion2Enabled) true else it[kDidShowRestore]
+                it[kDidShowRestore]
             }.firstOrNull() ?: false
         }
     }

--- a/app/src/main/java/com/trx/consumer/models/common/IAPErrorModel.kt
+++ b/app/src/main/java/com/trx/consumer/models/common/IAPErrorModel.kt
@@ -1,0 +1,25 @@
+package com.trx.consumer.models.common
+
+enum class IAPErrorModel {
+
+    MEMBERSHIPS,
+    USER,
+    MEMBERSHIP_ADD,
+    MEMBERSHIP_ADD_RESTORE,
+    NO_PRODUCT_ID_MATCH,
+    NEEDS_UPDATE,
+    RESTORE,
+    PURCHASE;
+
+    val display: String
+        get() = when (this) {
+            MEMBERSHIPS -> "Could not load memberships"
+            USER -> "Could not load your memberships"
+            MEMBERSHIP_ADD -> "There was a purchase error"
+            MEMBERSHIP_ADD_RESTORE -> "There was an error while restoring your purchases"
+            NO_PRODUCT_ID_MATCH -> "Could not find a matching product identifier"
+            PURCHASE -> "There was a Play Store error"
+            RESTORE -> "Could not restore your purchases"
+            NEEDS_UPDATE -> "Could not find products to restore"
+        }
+}

--- a/app/src/main/java/com/trx/consumer/models/common/MembershipModel.kt
+++ b/app/src/main/java/com/trx/consumer/models/common/MembershipModel.kt
@@ -1,6 +1,7 @@
 package com.trx.consumer.models.common
 
 import android.os.Parcelable
+import com.trx.consumer.extensions.capitalized
 import com.trx.consumer.extensions.format
 import com.trx.consumer.extensions.map
 import com.trx.consumer.extensions.toPrice
@@ -25,11 +26,12 @@ class MembershipModel(
     val revcatProductId: String = "",
     val entitlements: EntitlementsModel = EntitlementsModel(),
     var currentPeriodEnd: Long = 0,
-    var currentPeriodStart: Long = 0
+    var currentPeriodStart: Long = 0,
+    val billingPeriod: String = ""
 ) : Parcelable {
 
     val cost: String
-        get() = "${(priceInCents / 100.0).toPrice()} per Month"
+        get() = "${(priceInCents / 100.0).toPrice()} per ${billingPeriod.capitalized()}"
 
     val description: String
         get() = valueProps.joinToString(separator = "\n")
@@ -65,7 +67,8 @@ class MembershipModel(
                 revcatProductId = productId,
                 entitlements = jsonObject.optJSONObject("permissions")?.let {
                     EntitlementsModel.parse(it)
-                } ?: EntitlementsModel()
+                } ?: EntitlementsModel(),
+                billingPeriod = jsonObject.optString("billingPeriod")
             )
         }
 

--- a/app/src/main/java/com/trx/consumer/models/common/SettingsModel.kt
+++ b/app/src/main/java/com/trx/consumer/models/common/SettingsModel.kt
@@ -49,6 +49,7 @@ class SettingsModel {
             return mutableListOf<Any>().apply {
                 add(create(user, SettingsType.EMAIL))
                 add(create(user, SettingsType.MEMBERSHIPS))
+                add(create(user, SettingsType.RESTORE))
                 add(0)
                 add(create(null, SettingsType.SHOP))
                 add(create(null, SettingsType.GETTING_STARTED))

--- a/app/src/main/java/com/trx/consumer/models/common/UserMembershipModel.kt
+++ b/app/src/main/java/com/trx/consumer/models/common/UserMembershipModel.kt
@@ -10,7 +10,7 @@ class UserMembershipModel(
 ) {
 
     val isActive: Boolean
-        get() = status == "active"
+        get() = status == "active" || status == "trialing"
 
     companion object {
 

--- a/app/src/main/java/com/trx/consumer/screens/memberships/MembershipsFragment.kt
+++ b/app/src/main/java/com/trx/consumer/screens/memberships/MembershipsFragment.kt
@@ -43,6 +43,7 @@ class MembershipsFragment : BaseFragment(R.layout.fragment_memberships) {
             eventShowCancelActive.observe(viewLifecycleOwner, handleShowCancelActive)
             eventShowCancelMobile.observe(viewLifecycleOwner, handleShowCancelMobile)
             eventShowCancelWeb.observe(viewLifecycleOwner, handleShowCancelWeb)
+            eventShowRestore.observe(viewLifecycleOwner, handleShowRestore)
             eventShowHud.observe(viewLifecycleOwner, handleShowHud)
 
             doLoadView()
@@ -130,6 +131,11 @@ class MembershipsFragment : BaseFragment(R.layout.fragment_memberships) {
             setSecondaryButton(R.string.memberships_alert_secondary_label)
         }
         NavigationManager.shared.present(this, R.id.alert_fragment, model)
+    }
+
+    private val handleShowRestore = Observer<Void> {
+        LogManager.log("handleShowRestore")
+        NavigationManager.shared.present(this, R.id.restore_fragment)
     }
 
     private val handleShowHud = Observer<Boolean> { show ->

--- a/app/src/main/java/com/trx/consumer/screens/memberships/MembershipsViewModel.kt
+++ b/app/src/main/java/com/trx/consumer/screens/memberships/MembershipsViewModel.kt
@@ -3,14 +3,14 @@ package com.trx.consumer.screens.memberships
 import android.app.Activity
 import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.viewModelScope
-import com.revenuecat.purchases.Package
 import com.trx.consumer.base.BaseViewModel
 import com.trx.consumer.common.CommonLiveEvent
+import com.trx.consumer.extensions.params
 import com.trx.consumer.managers.BackendManager
-import com.trx.consumer.managers.CacheManager
 import com.trx.consumer.managers.IAPManager
 import com.trx.consumer.managers.LogManager
 import com.trx.consumer.managers.NativePurchaseManager
+import com.trx.consumer.models.common.IAPErrorModel
 import com.trx.consumer.models.common.MembershipModel
 import com.trx.consumer.models.core.ResponseModel
 import com.trx.consumer.models.responses.MembershipsResponseModel
@@ -20,7 +20,6 @@ import kotlinx.coroutines.launch
 
 class MembershipsViewModel @ViewModelInject constructor(
     private val backendManager: BackendManager,
-    private val cacheManager: CacheManager,
     private val nativePurchaseManager: NativePurchaseManager
 ) : BaseViewModel(), MembershipListener {
 
@@ -31,6 +30,7 @@ class MembershipsViewModel @ViewModelInject constructor(
     val eventShowCancelActive = CommonLiveEvent<Void>()
     val eventShowCancelMobile = CommonLiveEvent<Void>()
     val eventShowCancelWeb = CommonLiveEvent<Void>()
+    val eventShowRestore = CommonLiveEvent<Void>()
     val eventTapBack = CommonLiveEvent<Void>()
 
     private var memberships: List<MembershipModel> = emptyList()
@@ -44,12 +44,12 @@ class MembershipsViewModel @ViewModelInject constructor(
             eventShowHud.postValue(true)
             val membershipResponse = backendManager.memberships()
             if (!membershipResponse.isSuccess) {
-                eventLoadError.postValue("Could not load memberships")
+                eventLoadError.postValue(IAPErrorModel.MEMBERSHIPS.display)
                 return@launch
             }
             val userResponse = backendManager.user()
             if (!userResponse.isSuccess) {
-                eventLoadError.postValue("Could not load your memberships")
+                eventLoadError.postValue(IAPErrorModel.USER.display)
                 return@launch
             }
             try {
@@ -57,7 +57,6 @@ class MembershipsViewModel @ViewModelInject constructor(
                     membershipResponse.responseString
                 )
                 val user = UserResponseModel.parse(userResponse.responseString).user
-                cacheManager.user(user)
                 memberships = membershipsResponseModel.memberships(user.activeMemberships)
                 eventLoadView.postValue(memberships)
             } catch (e: Exception) {
@@ -77,49 +76,30 @@ class MembershipsViewModel @ViewModelInject constructor(
                 it.product.sku == model.revcatProductId
             } ?: run {
                 eventShowHud.postValue(false)
-                eventLoadError.postValue("Could not find a matching product identifier")
+                eventLoadError.postValue(IAPErrorModel.NO_PRODUCT_ID_MATCH.display)
                 return@launch
             }
 
             val purchase = IAPManager.shared.purchase(activity, matchingPackage)
             if (purchase.error != null) {
                 eventShowHud.postValue(false)
-                eventLoadError.postValue("There was an Play Store error")
+                eventLoadError.postValue(IAPErrorModel.PURCHASE.display)
                 return@launch
             }
 
-            val params = params(matchingPackage, model)
+            val params = matchingPackage.params(model.key)
             val response = backendManager.membershipAdd(params)
             if (response.isSuccess) {
                 doLoadView()
             } else {
-                eventLoadError.postValue("There was a purchase error")
+                eventLoadError.postValue(IAPErrorModel.MEMBERSHIP_ADD.display)
                 eventShowHud.postValue(false)
             }
         }
     }
 
     fun doTapRestore() {
-        viewModelScope.launch {
-            eventShowHud.postValue(true)
-            val packages = IAPManager.shared.offerings().packages
-            val model = IAPManager.shared.restore()
-            if (model.error != null) {
-                eventLoadError.postValue("There was a restore error")
-                eventShowHud.postValue(false)
-                return@launch
-            }
-
-            model.purchaserInfo?.activeSubscriptions?.forEach { productId ->
-                val matchingPackage = packages.firstOrNull { it.product.sku == productId }
-                val membership = memberships.firstOrNull { it.revcatProductId == productId }
-                if (matchingPackage != null && membership != null) {
-                    val params = params(matchingPackage, membership)
-                    backendManager.membershipAdd(params)
-                }
-            }
-            doLoadView()
-        }
+        eventShowRestore.call()
     }
 
     override fun doTapChoose(model: MembershipModel) {
@@ -142,15 +122,5 @@ class MembershipsViewModel @ViewModelInject constructor(
             }
             eventShowHud.postValue(false)
         }
-    }
-
-    fun params(matchingPackage: Package, membership: MembershipModel): HashMap<String, Any> {
-        return hashMapOf(
-            "subscriptionType" to membership.key,
-            "currency" to matchingPackage.product.priceCurrencyCode,
-            "subscriptionId" to matchingPackage.product.sku,
-            "paymentProcessor" to "REVCAT",
-            "priceInCents" to (matchingPackage.product.priceAmountMicros / 10000)
-        )
     }
 }

--- a/app/src/main/java/com/trx/consumer/screens/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/com/trx/consumer/screens/onboarding/OnboardingFragment.kt
@@ -18,7 +18,7 @@ class OnboardingFragment : BaseFragment(R.layout.fragment_onboarding) {
         viewModel.apply {
             eventLoadView.observe(viewLifecycleOwner, handleLoadView)
             eventTapClose.observe(viewLifecycleOwner, handleTapClose)
-            eventTapNext.observe(viewLifecycleOwner, handleTapNext)
+            eventShowRestore.observe(viewLifecycleOwner, handleShowRestore)
         }
 
         viewBinding.apply {
@@ -44,11 +44,11 @@ class OnboardingFragment : BaseFragment(R.layout.fragment_onboarding) {
         }
     }
 
-    private val handleTapClose = Observer<Void> {
-        NavigationManager.shared.loggedInLaunchSequence(this)
+    private val handleShowRestore = Observer<Void> {
+        NavigationManager.shared.present(this, R.id.restore_fragment)
     }
 
-    private val handleTapNext = Observer<Void> {
+    private val handleTapClose = Observer<Void> {
         NavigationManager.shared.loggedInLaunchSequence(this)
     }
 }

--- a/app/src/main/java/com/trx/consumer/screens/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/trx/consumer/screens/onboarding/OnboardingViewModel.kt
@@ -15,7 +15,7 @@ class OnboardingViewModel @ViewModelInject constructor(
 
     val eventLoadView = CommonLiveEvent<OnBoardingViewState>()
     val eventTapClose = CommonLiveEvent<Void>()
-    val eventTapNext = CommonLiveEvent<Void>()
+    val eventShowRestore = CommonLiveEvent<Void>()
 
     fun doLoadView() {
         viewModelScope.launch {
@@ -25,11 +25,17 @@ class OnboardingViewModel @ViewModelInject constructor(
     }
 
     fun doTapClose() {
-        eventTapClose.call()
+        viewModelScope.launch {
+            if (cacheManager.didShowRestore()) {
+                eventTapClose.call()
+            } else {
+                eventShowRestore.call()
+            }
+        }
     }
 
     fun onBackPressed() {
-        eventTapClose.call()
+        doTapPrevious()
     }
 
     fun doTapNext() {
@@ -37,14 +43,16 @@ class OnboardingViewModel @ViewModelInject constructor(
             state = OnBoardingViewState.getStateFromPage(state.currentPage + 1)
             eventLoadView.postValue(state)
         } else {
-            eventTapNext.call()
+            doTapClose()
         }
     }
 
-    fun doTapPrevious() {
+    private fun doTapPrevious() {
         if (state.currentPage != 0) {
             state = OnBoardingViewState.getStateFromPage(state.currentPage - 1)
             eventLoadView.postValue(state)
+        } else {
+            doTapClose()
         }
     }
 }

--- a/app/src/main/java/com/trx/consumer/screens/restore/RestoreFragment.kt
+++ b/app/src/main/java/com/trx/consumer/screens/restore/RestoreFragment.kt
@@ -1,0 +1,103 @@
+package com.trx.consumer.screens.restore
+
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
+import com.trx.consumer.BuildConfig
+import com.trx.consumer.R
+import com.trx.consumer.base.BaseFragment
+import com.trx.consumer.base.viewBinding
+import com.trx.consumer.databinding.FragmentRestoreBinding
+import com.trx.consumer.extensions.action
+import com.trx.consumer.managers.LogManager
+import com.trx.consumer.managers.NavigationManager
+import com.trx.consumer.managers.UtilityManager
+import com.trx.consumer.models.common.AlertModel
+import com.trx.consumer.screens.alert.AlertViewState
+
+class RestoreFragment : BaseFragment(R.layout.fragment_restore) {
+
+    private val viewModel: RestoreViewModel by viewModels()
+    private val viewBinding by viewBinding(FragmentRestoreBinding::bind)
+
+    override fun bind() {
+        viewModel.isFromOnboarding = NavigationManager.shared.previousFragment(
+            requireActivity()
+        ) == R.id.onboarding_fragment
+
+        viewBinding.apply {
+            btnBack.action { viewModel.doTapBack() }
+            btnClose.action { viewModel.doTapClose() }
+            btnRestore.action { viewModel.doTapRestore() }
+        }
+
+        viewModel.apply {
+            eventShowHud.observe(viewLifecycleOwner, handleShowHud)
+            eventShowHome.observe(viewLifecycleOwner, handleShowHome)
+            eventShowAlertSuccess.observe(viewLifecycleOwner, handleShowAlertSuccess)
+            eventShowAlertError.observe(viewLifecycleOwner, handleShowAlertError)
+            eventTapClose.observe(viewLifecycleOwner, handleTapClose)
+
+            doLoadView()
+        }
+    }
+
+    private val handleTapClose = Observer<Void> {
+        NavigationManager.shared.dismiss(this)
+    }
+
+    private val handleShowHud = Observer<Boolean> { show ->
+        LogManager.log("handleShowHud")
+        viewBinding.hudView.isVisible = show
+    }
+
+    private val handleShowAlertError = Observer<String> { error ->
+        LogManager.log("handleShowError")
+        val model = AlertModel.create(title = "", message = error).apply {
+            setPrimaryButton(
+                R.string.restore_alert_error_primary_label,
+                state = AlertViewState.POSITIVE
+            ) {
+                UtilityManager.shared.openUrl(
+                    requireContext(),
+                    BuildConfig.kGooglePlaySubscriptionsUrl
+                )
+            }
+            setSecondaryButton(R.string.restore_alert_error_secondary_label)
+        }
+        NavigationManager.shared.present(this, R.id.alert_fragment, model)
+    }
+
+    private val handleShowHome = Observer<String> { message ->
+        LogManager.log("handleShowConfirmHome")
+        val model = AlertModel.create(title = "", message = message).apply {
+            setPrimaryButton(
+                R.string.restore_home_alert_primary_label,
+                state = AlertViewState.POSITIVE
+            ) { NavigationManager.shared.loggedInLaunchSequence(this@RestoreFragment) }
+            setSecondaryButton(R.string.restore_alert_error_secondary_label)
+        }
+        NavigationManager.shared.present(this, R.id.alert_fragment, model)
+    }
+
+    private val handleShowAlertSuccess = Observer<Void> {
+        LogManager.log("handleShowConfirmHome")
+        val model = AlertModel.create(
+            title = "",
+            message = requireContext().getString(R.string.restore_alert_success_message)
+        ).apply {
+            setPrimaryButton(
+                R.string.restore_alert_success_primary_label,
+                state = AlertViewState.POSITIVE
+            ) {
+                NavigationManager.shared.dismiss(this@RestoreFragment)
+                NavigationManager.shared.dismiss(this@RestoreFragment)
+            }
+            setSecondaryButton(R.string.restore_alert_error_secondary_label)
+        }
+        NavigationManager.shared.present(this, R.id.alert_fragment, model)
+    }
+
+    override fun onBackPressed() {
+        viewModel.doTapBack()
+    }
+}

--- a/app/src/main/java/com/trx/consumer/screens/restore/RestoreViewModel.kt
+++ b/app/src/main/java/com/trx/consumer/screens/restore/RestoreViewModel.kt
@@ -1,0 +1,125 @@
+package com.trx.consumer.screens.restore
+
+import androidx.hilt.lifecycle.ViewModelInject
+import androidx.lifecycle.viewModelScope
+import com.trx.consumer.base.BaseViewModel
+import com.trx.consumer.common.CommonLiveEvent
+import com.trx.consumer.extensions.params
+import com.trx.consumer.managers.BackendManager
+import com.trx.consumer.managers.CacheManager
+import com.trx.consumer.managers.IAPManager
+import com.trx.consumer.managers.LogManager
+import com.trx.consumer.managers.NativePurchaseManager
+import com.trx.consumer.models.common.IAPErrorModel
+import com.trx.consumer.models.core.ResponseModel
+import com.trx.consumer.models.responses.MembershipsResponseModel
+import com.trx.consumer.models.responses.UserResponseModel
+import com.trx.consumer.screens.welcome.WelcomeState
+import kotlinx.coroutines.launch
+
+class RestoreViewModel @ViewModelInject constructor(
+    private val backendManager: BackendManager,
+    private val cacheManager: CacheManager,
+    private val nativePurchaseManager: NativePurchaseManager
+) : BaseViewModel() {
+
+    var isFromOnboarding = true
+
+    val eventLoadView = CommonLiveEvent<WelcomeState>()
+    val eventTapClose = CommonLiveEvent<Void>()
+    val eventShowAlertError = CommonLiveEvent<String>()
+    val eventShowAlertSuccess = CommonLiveEvent<Void>()
+    val eventShowHome = CommonLiveEvent<String>()
+    val eventShowHud = CommonLiveEvent<Boolean>()
+
+    fun doLoadView() {
+        viewModelScope.launch {
+            cacheManager.didShowRestore(true)
+        }
+    }
+
+    fun doTapRestore() {
+        viewModelScope.launch {
+            eventShowHud.postValue(true)
+            val membershipResponse = backendManager.memberships()
+            if (!membershipResponse.isSuccess) {
+                eventShowAlertError.postValue(IAPErrorModel.RESTORE.display)
+                return@launch
+            }
+            val userResponse = backendManager.user()
+            if (!userResponse.isSuccess) {
+                eventShowAlertError.postValue(IAPErrorModel.RESTORE.display)
+                return@launch
+            }
+            try {
+                val membershipsResponseModel = MembershipsResponseModel.parse(
+                    membershipResponse.responseString
+                )
+                val userMemberships = UserResponseModel
+                    .parse(userResponse.responseString)
+                    .user
+                    .activeMemberships
+                val packages = IAPManager.shared.offerings().packages
+
+                val trxProducts = membershipsResponseModel.memberships(userMemberships)
+                val trxUserProducts = trxProducts.filter { it.isActive }.map { it.revcatProductId }
+                val nativeProducts = nativePurchaseManager.purchases().map { it.sku }
+                val rcProducts = IAPManager.shared.purchases().purchaserInfo?.activeSubscriptions
+                    ?: emptyList()
+
+                val needsUpdateProducts = nativeProducts - trxUserProducts
+                val needsRestoreProducts = nativeProducts - rcProducts
+
+                if (needsUpdateProducts.isNotEmpty()) {
+                    if (needsRestoreProducts.isNotEmpty()) {
+                        val result = IAPManager.shared.restore()
+                        if (result.error != null) {
+                            eventShowAlertError.postValue(IAPErrorModel.RESTORE.display)
+                            return@launch
+                        }
+                    }
+                    var backendError = ""
+
+                    needsUpdateProducts.forEach { productId ->
+                        val matchingPackage = packages.firstOrNull { it.product.sku == productId }
+                        val membership = trxProducts.firstOrNull { it.revcatProductId == productId }
+                        if (matchingPackage != null && membership != null) {
+                            val params = matchingPackage.params(membership.key)
+                            val response = backendManager.membershipAdd(params)
+                            if (!response.isSuccess) {
+                                backendError = IAPErrorModel.MEMBERSHIP_ADD_RESTORE.display
+                            }
+                        }
+                    }
+                    backendManager.user()
+                    if (backendError.isNotEmpty()) {
+                        eventShowAlertError.postValue(backendError)
+                    } else {
+                        if (isFromOnboarding) {
+                            eventShowHome.postValue("Purchases restored successfully")
+                        } else {
+                            eventShowAlertSuccess.call()
+                        }
+                    }
+                } else {
+                    eventShowAlertError.postValue(IAPErrorModel.NEEDS_UPDATE.display)
+                }
+            } catch (e: Exception) {
+                LogManager.log(e)
+                eventShowAlertError.postValue(ResponseModel.parseErrorMessage)
+            }
+        }.invokeOnCompletion { eventShowHud.postValue(false) }
+    }
+
+    fun doTapBack() {
+        doTapClose()
+    }
+
+    fun doTapClose() {
+        if (isFromOnboarding) {
+            eventShowHome.postValue("You will be taken to Home")
+        } else {
+            eventTapClose.call()
+        }
+    }
+}

--- a/app/src/main/java/com/trx/consumer/screens/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/trx/consumer/screens/settings/SettingsFragment.kt
@@ -47,9 +47,9 @@ class SettingsFragment : BaseFragment(R.layout.fragment_settings) {
             eventTapLogout.observe(viewLifecycleOwner, handleTapLogout)
             eventTapBack.observe(viewLifecycleOwner, handleTapBack)
             eventLogOut.observe(viewLifecycleOwner, handleLogOut)
-            eventTapMembership.observe(viewLifecycleOwner, handleTapMembership)
             eventTapTest.observe(viewLifecycleOwner, handleTapTest)
             eventTapMaintenance.observe(viewLifecycleOwner, handleTapMaintenance)
+            eventTapRestore.observe(viewLifecycleOwner, handleTapRestore)
             doLoadView()
         }
     }
@@ -67,6 +67,11 @@ class SettingsFragment : BaseFragment(R.layout.fragment_settings) {
     private val handleTapMemberships = Observer<Void> {
         LogManager.log("handleTapMemberships")
         NavigationManager.shared.present(this, R.id.memberships_fragment)
+    }
+
+    private val handleTapRestore = Observer<Unit> {
+        LogManager.log("handleTapMemberships")
+        NavigationManager.shared.present(this, R.id.restore_fragment)
     }
 
     private val handleTapShop = Observer<Void> {
@@ -87,11 +92,6 @@ class SettingsFragment : BaseFragment(R.layout.fragment_settings) {
     private val handleTapTermsAndConditions = Observer<Void> {
         LogManager.log("handleTapTermsAndConditions")
         UtilityManager.shared.openUrl(requireContext(), kTermsConditionsUrl)
-    }
-
-    private val handleTapMembership = Observer<Void> {
-        LogManager.log("handleTapTermsAndConditions")
-        NavigationManager.shared.present(this, R.id.memberships_fragment)
     }
 
     private val handleTapLogout = Observer<Void> {

--- a/app/src/main/java/com/trx/consumer/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/trx/consumer/screens/settings/SettingsViewModel.kt
@@ -6,7 +6,6 @@ import com.trx.consumer.base.BaseViewModel
 import com.trx.consumer.common.CommonLiveEvent
 import com.trx.consumer.managers.BackendManager
 import com.trx.consumer.managers.CacheManager
-import com.trx.consumer.managers.LogManager
 import com.trx.consumer.models.common.SettingsModel
 import com.trx.consumer.models.common.SettingsType
 import com.trx.consumer.screens.settings.option.SettingsOptionListener
@@ -30,8 +29,8 @@ class SettingsViewModel @ViewModelInject constructor(
     val eventTapLogout = CommonLiveEvent<Void>()
     val eventTapBack = CommonLiveEvent<Void>()
     val eventTapTest = CommonLiveEvent<Void>()
-    val eventTapMembership = CommonLiveEvent<Void>()
     val eventTapMaintenance = CommonLiveEvent<Unit>()
+    val eventTapRestore = CommonLiveEvent<Unit>()
 
     val eventLogOut = CommonLiveEvent<Void>()
 
@@ -53,10 +52,10 @@ class SettingsViewModel @ViewModelInject constructor(
             SettingsType.GETTING_STARTED -> eventTapGettingStarted.call()
             SettingsType.CONTACT_SUPPORT -> eventTapContactSupport.call()
             SettingsType.TERMS_AND_CONDITIONS -> eventTapTermsAndConditions.call()
-            SettingsType.RESTORE -> LogManager.log("doTapSetting - RESTORE")
+            SettingsType.RESTORE -> eventTapRestore.call()
             SettingsType.LOGOUT -> eventTapLogout.call()
             SettingsType.TEST_SCREENS -> eventTapTest.call()
-            SettingsType.MEMBERSHIPS -> eventTapMembership.call()
+            SettingsType.MEMBERSHIPS -> eventTapMemberships.call()
             SettingsType.SHOW_MAINTENANCE -> eventTapMaintenance.call()
         }
     }

--- a/app/src/main/java/com/trx/consumer/screens/welcome/WelcomeState.kt
+++ b/app/src/main/java/com/trx/consumer/screens/welcome/WelcomeState.kt
@@ -4,12 +4,11 @@ import androidx.annotation.StringRes
 import com.trx.consumer.R
 
 enum class WelcomeState {
-    RESTORE, WELCOME, PROMO;
+    WELCOME, PROMO;
 
     @get:StringRes
     val buttonTitle: Int
         get() = when (this) {
-            RESTORE -> R.string.welcome_state_restore_button_label
             WELCOME -> R.string.welcome_state_welcome_button_label
             PROMO -> R.string.welcome_state_promo_button_label
         }
@@ -17,7 +16,6 @@ enum class WelcomeState {
     @get:StringRes
     val title: Int
         get() = when (this) {
-            RESTORE -> R.string.welcome_state_restore_title
             WELCOME -> R.string.welcome_state_welcome_title
             PROMO -> R.string.welcome_state_promo_title
         }
@@ -25,7 +23,6 @@ enum class WelcomeState {
     @get:StringRes
     val description: Int
         get() = when (this) {
-            RESTORE -> R.string.welcome_state_restore_description
             WELCOME -> R.string.welcome_state_welcome_description
             PROMO -> R.string.welcome_state_promo_description
         }

--- a/app/src/main/res/layout/fragment_restore.xml
+++ b/app/src/main/res/layout/fragment_restore.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.trx.consumer.common.CommonView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.trx.consumer.common.CommonImageView
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:scaleType="centerCrop"
+        android:src="@drawable/img_media_welcome"
+        android:tint="@color/black_semi_trans"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.trx.consumer.common.CommonView
+        android:id="@+id/layoutNavBar"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/top_bar_height"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.trx.consumer.common.CommonImageView
+            android:id="@+id/btnBack"
+            android:layout_width="35dp"
+            android:layout_height="35dp"
+            android:layout_marginStart="5dp"
+            android:scaleType="centerInside"
+            android:src="@drawable/ic_btn_back_white"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.trx.consumer.common.CommonImageView
+            android:id="@+id/btnClose"
+            android:layout_width="35dp"
+            android:layout_height="35dp"
+            android:layout_marginEnd="5dp"
+            android:scaleType="centerInside"
+            android:src="@drawable/ic_btn_close_white"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </com.trx.consumer.common.CommonView>
+
+    <com.trx.consumer.common.CommonLabel
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:fontFamily="@font/atcarquette_bold"
+        android:text="@string/welcome_get_started_label"
+        android:textAllCaps="true"
+        android:textColor="@color/yellow"
+        android:textSize="12sp"
+        app:layout_constraintBottom_toTopOf="@+id/lblTitle"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <com.trx.consumer.common.CommonLabel
+        android:id="@+id/lblTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:text="@string/restore_title"
+        android:textColor="@color/white"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@+id/lblDescription"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <com.trx.consumer.common.CommonLabel
+        android:id="@+id/lblDescription"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="32dp"
+        android:fontFamily="@font/atcarquette_regular"
+        android:text="@string/restore_description"
+        android:textColor="@color/white"
+        android:textSize="15sp"
+        app:layout_constraintBottom_toTopOf="@+id/btnRestore"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <com.trx.consumer.common.CommonButton
+        android:id="@+id/btnRestore"
+        android:layout_width="0dp"
+        android:layout_height="50dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="40dp"
+        android:fontFamily="@font/atcarquette_bold"
+        android:gravity="center"
+        android:text="@string/restore_button_label"
+        android:textAllCaps="true"
+        android:textColor="@color/white"
+        android:textSize="14sp"
+        android:visibility="visible"
+        app:backgroundColor="@color/black"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <com.trx.consumer.common.CommonHudView
+        android:id="@+id/hudView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</com.trx.consumer.common.CommonView>

--- a/app/src/main/res/navigation/nav_main.xml
+++ b/app/src/main/res/navigation/nav_main.xml
@@ -186,4 +186,10 @@
         android:label="MaintenanceFragment"
         tools:layout="@layout/fragment_maintenance" />
 
+    <fragment
+        android:id="@+id/restore_fragment"
+        android:name="com.trx.consumer.screens.restore.RestoreFragment"
+        android:label="RestoreFragment"
+        tools:layout="@layout/fragment_restore" />
+
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,6 +138,15 @@
     <string name="player_end_workout_button_label">END WORKOUT</string>
     <string name="player_screen_cast_coming_soon_message">Coming Soon!</string>
 
+    <string name="restore_button_label">Restore Purchases</string>
+    <string name="restore_title">Welcome to the club!</string>
+    <string name="restore_description">With 3 new ways to train, TRX Training Club is your all-in-one virtual gym helping you to crush any goal. Anytime. Anywhere.</string>
+    <string name="restore_home_alert_primary_label">GO TO HOME</string>
+    <string name="restore_alert_error_primary_label">GO TO PLAY STORE</string>
+    <string name="restore_alert_error_secondary_label">DISMISS</string>
+    <string name="restore_alert_success_message">Purchases successfully restored</string>
+    <string name="restore_alert_success_primary_label">TAKE ME BACK</string>
+
     <string name="settings_title">SETTINGS</string>
     <string name="settings_email">Email</string>
     <string name="settings_memberships">Memberships</string>
@@ -254,13 +263,10 @@
     <string name="welcome_get_started_label">Get Started</string>
     <string name="welcome_state_welcome_button_label">Continue</string>
     <string name="welcome_state_promo_button_label">Promo</string>
-    <string name="welcome_state_restore_button_label">Restore</string>
     <string name="welcome_state_welcome_title">Welcome to the club,\n%1s</string>
     <string name="welcome_state_promo_title">Promo title</string>
-    <string name="welcome_state_restore_title">Restore title</string>
     <string name="welcome_state_welcome_description">With 3 new ways to train, TRX Training Club is your all-in-one virtual gym helping you to crush any goal. Anytime. Anywhere.</string>
     <string name="welcome_state_promo_description">Promo description</string>
-    <string name="welcome_state_restore_description">Restore description</string>
 
     <string name="workout_profile_label">Profile</string>
     <string name="workout_book_session_label">Book Session</string>


### PR DESCRIPTION
## Description
Introduce and connect `Restore` screen

### Summary

- [x] Display `Restore` from Onboarding, Settings. and Memberships
- [x] Use native purchases to determine revcat restore + be update
- [x] Display appropriate success and error messages 

### Issue

[TCM-579](https://hyfnla.atlassian.net/browse/TCM-579)

### Video/Screenshot

[Onboarding restore no purchases](https://drive.google.com/file/d/1xqPGnFjTgnTmuX2mNuudN0tEKKiuq4uG/view?usp=sharing)
[Onboarding restore success](https://drive.google.com/file/d/1Ylw9ap_P7GTmGHHEVAbBGybKcaXlL4S9/view?usp=sharing)
[Restore success](https://drive.google.com/file/d/1Ylw9ap_P7GTmGHHEVAbBGybKcaXlL4S9/view?usp=sharing)
[Settings/Memberships restore no purchases](https://drive.google.com/file/d/1hYSlsHNAbYNNkq8FYRiSXt50MWTofXZ_/view?usp=sharing)