### PR TITLE
TCM-571 | Fix `ErrorAlert` dismiss

### DIFF
--- a/app/src/main/java/com/trx/consumer/screens/erroralert/ErrorAlertFragment.kt
+++ b/app/src/main/java/com/trx/consumer/screens/erroralert/ErrorAlertFragment.kt
@@ -47,12 +47,12 @@ class ErrorAlertFragment : BaseDialogFragment(R.layout.fragment_error_alert) {
 
     private val handleTapOutside = Observer<Void> {
         LogManager.log("handleTapOutside")
-        NavigationManager.shared.dismiss(this)
+        dismiss()
     }
 
     private val handleTapDismiss = Observer<Void> {
         LogManager.log("handleTapDismiss")
-        NavigationManager.shared.dismiss(this)
+        dismiss()
     }
 
     override fun dismiss() {


### PR DESCRIPTION
## Description

### Summary

- [x] Dismiss called instead of Navigation dismiss in ErrorAlert

### Issue

[TCM-571](https://hyfnla.atlassian.net/browse/TCM-571)

### Video/Screenshot

None