### PR TITLE
TCM-735 | Exclude x86 for Release only

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,10 +56,6 @@ android {
         kotlinOptions {
             jvmTarget = JavaVersion.VERSION_1_8
         }
-
-        ndk {
-            abiFilters "arm64-v8a", "armeabi-v7a"
-        }
     }
 
     packagingOptions {
@@ -86,6 +82,9 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             resValue "bool", "debug", "false"
+            ndk {
+                abiFilters "arm64-v8a", "armeabi-v7a"
+            }
         }
         debug {
             minifyEnabled false


### PR DESCRIPTION
## Description

### Summary

- Move `abiFilters` to only be excluded in release build

### Issue

[TCM-735](https://hyfnla.atlassian.net/browse/TCM-735)

### Video/Screenshot

N/A refer to files changed