### PR TITLE
TCM-677 | Improve video cell frames for images

### DIFF
--- a/app/src/main/res/layout/row_video_workout.xml
+++ b/app/src/main/res/layout/row_video_workout.xml
@@ -10,11 +10,9 @@
         android:id="@+id/imgBg"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:backgroundTint="@color/black"
-        android:scaleType="centerCrop"
-        android:tint="@color/blackAlpha20"
-        tools:src="@drawable/ic_img_placeholder"
-        tools:tint="@color/blackAlpha20" />
+        android:background="@color/black"
+        android:scaleType="centerInside"
+        tools:src="@drawable/ic_img_placeholder" />
 
     <com.trx.consumer.common.CommonLabel
         android:id="@+id/lblWorkout"


### PR DESCRIPTION
## Description

### Summary

- [x] change the video workout cell images scale type to centerInside
- [x] adjust the overlay to match iOS and design

### Issue

[TCM-677](https://hyfnla.atlassian.net/browse/TCM-677)

### Video/Screenshot

| Before | After |
|----|----|
|![android_before](https://user-images.githubusercontent.com/2285343/125716465-a8a2a418-57f9-4cdd-b1bc-3a47e23775f6.png)|![android_after](https://user-images.githubusercontent.com/2285343/125716463-30b0c4ca-9797-4663-b712-2fa64162c829.png)|

